### PR TITLE
Add requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,7 @@
+musicbrainzngs==0.7.1
+numpy==1.24.1
+Pillow==9.4.0
+py2exe==0.13.0.0
+pyOpenSSL==23.0.0
+python_dateutil==2.8.2
+urllib3==1.26.13

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,6 @@
 musicbrainzngs==0.7.1
 numpy==1.24.1
 Pillow==9.4.0
-py2exe==0.13.0.0
 pyOpenSSL==23.0.0
 python_dateutil==2.8.2
 urllib3==1.26.13


### PR DESCRIPTION
To make it easier to pip install the required packages, rather than relying on exceptions to figure out the missing ones.