### PR TITLE
Add `NRSC5DUI_DATA` environment variable

### DIFF
--- a/nrsc5-dui.py
+++ b/nrsc5-dui.py
@@ -53,12 +53,13 @@ else:
 
 if "NRSC5DUI_DATA" in os.environ:
     userDataDir = os.environ["NRSC5DUI_DATA"]
+    os.makedirs(userDataDir, exist_ok=True)
 else:
     userDataDir = runtimeDir
 
 aasDir = os.path.join(userDataDir, "aas")  # aas (data from nrsc5) file directory
 mapDir = os.path.join(userDataDir, "map")  # map (data we process) file directory
-resDir = os.path.join(userDataDir, "res")  # resource (application dependencies) file directory
+resDir = os.path.join(runtimeDir, "res")  # resource (application dependencies) file directory
 cfgDir = os.path.join(userDataDir, "cfg")  # config file directory
 
 class NRSC5_DUI(object):

--- a/nrsc5-dui.py
+++ b/nrsc5-dui.py
@@ -2069,7 +2069,10 @@ class NRSC5_DUI(object):
             with open(os.path.join(cfgDir,"coverMetas.json"), mode='w') as f:
                 json.dump(self.coverMetas, f, indent=2)
         except Exception as e:
-            print(e.message, e.args)
+            try:
+                print(e.message, e.args)
+            except:
+                print(e)
             self.debugLog("Error: Unable to save config", True)
     
     def debugLog(self, message, force=False):

--- a/nrsc5-dui.py
+++ b/nrsc5-dui.py
@@ -1982,7 +1982,7 @@ class NRSC5_DUI(object):
                 os.mkdir(cfgDir)
                 self.debugLog("Needed to create config directory!")
             except:
-                self.debugLog("Error: Unable to create AAS directory", True)
+                self.debugLog("Error: Unable to create config directory", True)
                 cfgDir = None
 
         # create aas directory

--- a/nrsc5-dui.py
+++ b/nrsc5-dui.py
@@ -51,14 +51,19 @@ if hasattr(sys, 'frozen'):
 else:
     runtimeDir = sys.path[0]
 
-aasDir = os.path.join(runtimeDir, "aas")  # aas (data from nrsc5) file directory
-mapDir = os.path.join(runtimeDir, "map")  # map (data we process) file directory
-resDir = os.path.join(runtimeDir, "res")  # resource (application dependencies) file directory
-cfgDir = os.path.join(runtimeDir, "cfg")  # config file directory
+if "NRSC5DUI_DATA" in os.environ:
+    userDataDir = os.environ["NRSC5DUI_DATA"]
+else:
+    userDataDir = runtimeDir
+
+aasDir = os.path.join(userDataDir, "aas")  # aas (data from nrsc5) file directory
+mapDir = os.path.join(userDataDir, "map")  # map (data we process) file directory
+resDir = os.path.join(userDataDir, "res")  # resource (application dependencies) file directory
+cfgDir = os.path.join(userDataDir, "cfg")  # config file directory
 
 class NRSC5_DUI(object):
     def __init__(self):
-        global runtimeDir, resDir, imgLANCZOS
+        global runtimeDir, userDataDir, resDir, imgLANCZOS
 
         self.windowsOS = False          # save our determination as a var in case we change how we determine.
 
@@ -67,6 +72,7 @@ class NRSC5_DUI(object):
         self.http = urllib3.PoolManager()
 
         self.debugLog("Local path determined as " + runtimeDir)
+        self.debugLog("User data base directory: " + userDataDir)
 
         if (platform.system() == 'Windows'):
             # Windows release layout

--- a/nrsc5-dui.py
+++ b/nrsc5-dui.py
@@ -2068,7 +2068,8 @@ class NRSC5_DUI(object):
 
             with open(os.path.join(cfgDir,"coverMetas.json"), mode='w') as f:
                 json.dump(self.coverMetas, f, indent=2)
-        except:
+        except Exception as e:
+            print e.message, e.args
             self.debugLog("Error: Unable to save config", True)
     
     def debugLog(self, message, force=False):

--- a/nrsc5-dui.py
+++ b/nrsc5-dui.py
@@ -1976,6 +1976,15 @@ class NRSC5_DUI(object):
         except:
             self.debugLog("Error: Unable to load config", True)
         
+        # create cfg directory
+        if (not os.path.isdir(cfgDir)):
+            try:
+                os.mkdir(cfgDir)
+                self.debugLog("Needed to create config directory!")
+            except:
+                self.debugLog("Error: Unable to create AAS directory", True)
+                cfgDir = None
+
         # create aas directory
         if (not os.path.isdir(aasDir)):
             try:

--- a/nrsc5-dui.py
+++ b/nrsc5-dui.py
@@ -2069,7 +2069,7 @@ class NRSC5_DUI(object):
             with open(os.path.join(cfgDir,"coverMetas.json"), mode='w') as f:
                 json.dump(self.coverMetas, f, indent=2)
         except Exception as e:
-            print e.message, e.args
+            print(e.message, e.args)
             self.debugLog("Error: Unable to save config", True)
     
     def debugLog(self, message, force=False):


### PR DESCRIPTION
This PR adds an environment variable intended for use when `nrsc5-dui` is installed somewhere immutable. A few fixes for assumptions about the runtime environment were applied. I also had it print the actual error when it failed to write the config file (as this was an issue I was having).

When `NRSC5DUI_DATA` is set to a writeable, empty directory:
* `nrsc5-dui` creates the cfg, aas, and map directories
* Those directories are not based on `runtimeDir` but instead based on the directory given

When `NRSC5DUI_DATA` is not set:
* `nrsc5-dui` assumes its value is the `runtimeDir` and proceeds as normal

It may be beneficial to apply this as a "squash" merge.